### PR TITLE
Fixed projection function on ggd array

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "IMASggd"
 uuid = "b7b5e640-9b39-4803-84eb-376048795def"
 authors = ["Anchal Gupta <guptaa@fusion.gat.com>"]
-version = "3.2.2"
+version = "3.3.0"
 
 [deps]
 ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"

--- a/src/subset_tools.jl
+++ b/src/subset_tools.jl
@@ -271,7 +271,7 @@ end
 
 """
     project_prop_on_subset!(
-        prop_arr::IMASdd.IDSvector{<:all__grid_subset_prop},
+        prop_arr, # ::IMASdd.IDSvector{<:all__grid_subset_prop}
         from_subset::all__grid_subset,
         to_subset::all__grid_subset;
         space::all__space=get_space(from_subset),
@@ -316,7 +316,7 @@ the additional utility, this function also returns a tuple
     new instance
 """
 function project_prop_on_subset!(
-    prop_arr::IMASdd.IDSvector{<:all__grid_subset_prop},
+    prop_arr, # ::IMASdd.IDSvector{<:all__grid_subset_prop}
     from_subset::all__grid_subset,
     to_subset::all__grid_subset;
     space::all__space=get_space(from_subset),
@@ -392,7 +392,7 @@ end
 
 """
     project_prop_on_subset!(
-        ggds::IMASdd.IDSvector{<:all__ggd},
+        ggds::Union{Vector{<:all__ggd}, IMASdd.IDSvector{<:all__ggd}},
         prop_path::String,
         from_subset::all__grid_subset,
         to_subset::all__grid_subset;
@@ -415,7 +415,7 @@ do the projection for all the states of the `ion`. This function call returns a 
 list of return tuples for all projections performed.
 """
 function project_prop_on_subset!(
-    ggds::IMASdd.IDSvector{<:all__ggd},
+    ggds::Union{Vector{<:all__ggd}, IMASdd.IDSvector{<:all__ggd}},
     prop_path::String,
     from_subset::all__grid_subset,
     to_subset::all__grid_subset;
@@ -426,13 +426,14 @@ function project_prop_on_subset!(
         from_subset,
     ),
 ) where {U <: Real}
-    prop_arrays = Array{IMASdd.IDSvector{<:all__grid_subset_prop}}[]
+    prop_arrays = []
     for ggd ∈ ggds
-        append!(prop_arrays, _prop_arrays_from_path(prop_path::String, ggd))
+        prop_arrays = [prop_arrays; _prop_arrays_from_path(prop_path, ggd)]
     end
+
     to_return = []
     for prop_arr ∈ prop_arrays
-        append!(
+        push!(
             to_return,
             project_prop_on_subset!(
                 prop_arr,
@@ -448,7 +449,6 @@ function project_prop_on_subset!(
 end
 
 function _prop_arrays_from_path(prop_path::String, parent)
-    prop_arrays = Array{IMASdd.IDSvector{<:all__grid_subset_prop}}[]
     if occursin(".", prop_path)
         pf = split(prop_path, ".")[1]
         rem_path = prop_path[(findfirst('.', prop_path)+1):end]
@@ -456,19 +456,22 @@ function _prop_arrays_from_path(prop_path::String, parent)
             new_parent = getfield(parent, Symbol(pf[1:(findfirst('[', pf)-1)]))
             ind_str = pf[(findfirst('[', pf)+1):(findfirst(']', pf)-1)]
             if ind_str == ":"
+                prop_arrays = []
                 for np ∈ new_parent
-                    append!(prop_arrays, _prop_arrays_from_path(rem_path, np))
+                    prop_arrays = [prop_arrays; _prop_arrays_from_path(rem_path, np)]
                 end
+                return prop_arrays
             else
                 ind = parse(Int, ind_str)
-                append!(prop_arrays, _prop_arrays_from_path(rem_path, new_parent[ind]))
+                return _prop_arrays_from_path(rem_path, new_parent[ind])
             end
         else
             new_parent = getfield(parent, Symbol(pf))
-            append!(prop_arrays, _prop_arrays_from_path(rem_path, new_parent))
+            return _prop_arrays_from_path(rem_path, new_parent)
         end
+    else
+        return [getfield(parent, Symbol(prop_path))]
     end
-    return prop_arrays
 end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -201,7 +201,7 @@ if args["projection"]
                 from_subset,
                 to_subset,
             )
-        @test true
+        @test length(projection_return) == length(idstd.edge_profiles.ggd)
     end
 end
 


### PR DESCRIPTION
project_prop_on_subset! function  has been changed so that it does not restrict the input type anymore. The input type restriction was causing too much overhead in compilation (potentially a julia issue) but we aren't wining anything right now by fixing the type.

The overhead comes when during compile time the script does not know the type of the input. This was happening in the second method which takes a string path from the ggd array to the property. Since this string path can be anything, the compiler goes into endless computation in pre-compile step and gets stuck without giving any warning or errors. I suspect another overflow issue similar to https://github.com/JuliaLang/julia/issues/58129 fixed in https://github.com/JuliaLang/julia/pull/58159 .